### PR TITLE
Include fingerprints directly on the page

### DIFF
--- a/pgp_listing.py
+++ b/pgp_listing.py
@@ -29,14 +29,14 @@ def render_page(groups):
 
 groups = [
     Group('B', [
-        Entry('David Blishen', 'blishen pk', 'blishen fp'),
-        Entry('Michael Barton', 'barton pk', 'barton fp')
+        Entry('David Blishen', 'blishen pk', 'A820 60D2 AA7F E79C 98B7  43A1 A287 2CF2 263E 3238'),
+        Entry('Michael Barton', 'barton pk', '578E D4D8 23DE 6042 D189  A0DB 6AC4 9BE0 7B37 BC8C')
     ]),
     Group('C', [
-        Entry('Sam Cutler', 'cutler pk', 'cutler fp')
+        Entry('Sam Cutler', 'cutler pk', '5A83 E099 6D3A B407 52C1  CF5F B553 86B7 867B A22B')
     ]),
     Group('W', [
-        Entry('Kate Whalen', 'whalen pk', 'whalen fp')
+        Entry('Kate Whalen', 'whalen pk', '6FD2 E4C9 71AD B9BB 1573  85EA 383B C341 85FB BD09')
     ])
 ]
 

--- a/static/public.css
+++ b/static/public.css
@@ -142,6 +142,23 @@ ol {
     display: none;
 }
 
+.entry__name {
+    font-weight: 600;
+}
+
+.fingerprint__label {
+    margin-top: 12px;
+    font-family: Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+
+}
+
+.fingerprint {
+    font-family: monospace;
+    margin: 12px;
+    padding: 6px;
+    background-color: #f7f7f7;
+}
+
 .section-terms {
     background-color: #f7f7f7;
     border-top: 1px solid #dcdcdc;

--- a/templates/public/pgp-listing.html
+++ b/templates/public/pgp-listing.html
@@ -58,12 +58,10 @@
                 <li class="collection-header"><h4>{{ group.heading }}</h4></li>
                 {% for entry in group.entries %}
                     <li class="collection-item js-entry">
-                        <div>
-                            <span class="js-name">{{ entry.name }}</span>
-                            <div class="secondary-content">
-                                <a class="entry__link" href='{{ entry.publickey }}'>Public Key</a>
-                                <a class="entry__link" href='{{ entry.fingerprint }}'>Fingerprint</a>
-                            </div>
+                        <div class="row">
+                            <div class="col s6 entry__name js-name">{{ entry.name }}</div>
+                            <div class="col s6"><a class="entry__link" href='{{ entry.publickey }}'>Public Key</a></div>
+                            <div class="col s12 fingerprint__label">Fingerprint: <span class="fingerprint">{{ entry.fingerprint }}</span></div>
                         </div>
                     </li>
                 {% endfor %}


### PR DESCRIPTION
Should we link to the fingerprints, or include them directly on the page?

Here is a potential design for the latter:

<img width="927" alt="Screenshot 2019-06-07 at 22 52 00" src="https://user-images.githubusercontent.com/8607683/59186276-5f1c5f80-8b6a-11e9-9ea2-8d36b2e10be9.png">

This would simplify the user flow, by reducing the number of clicks they need to get the information they want. This would also make the pgp-manager task simpler since it would only need to copy the public key files from the data bucket to the public bucket.

