### PR TITLE
Making the PGP site generation work as an AWS lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,10 @@ pip-selfcheck.json
 
 .DS_Store
 .vscode
+.idea
 __pycache__
 
 # Outputted and generated files
 
 /build/
+/package/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# ---- Base Python ----
+FROM python:3.7
+WORKDIR /secure-contact
+
+# ---- Dependencies ---- 
+COPY requirements.txt /secure-contact/requirements.txt
+RUN pip install -r requirements.txt
+
+# --- SRC and scripts ---
+COPY static /secure-contact/static
+COPY templates /secure-contact/templates
+COPY pgp_listing.py /secure-contact/
+COPY pgp_manager.py /secure-contact/
+
+CMD python /secure-contact/pgp_listing.py

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+rm lambda.zip
+
+pip install --target ./package -r requirements.txt
+
+cd package
+zip -r9 ${OLDPWD}/lambda.zip .
+cd $OLDPWD
+zip -gr lambda.zip static
+zip -gr lambda.zip templates
+zip -g lambda.zip pgp_listing.py
+zip -g lambda.zip pgp_manager.py

--- a/cloudformation/secure-contact-lambda.yaml
+++ b/cloudformation/secure-contact-lambda.yaml
@@ -186,7 +186,7 @@ Resources:
         Bucket: !Ref ArtifactBucket
         Key: !Sub ${Stack}/${Stage}/${App}/lambda.zip
       Runtime: python3.7
-      Handler: app.pgp_listing
+      Handler: pgp_listing
       Environment:
         Variables:
           STAGE: !Ref Stage

--- a/cloudformation/secure-contact-lambda.yaml
+++ b/cloudformation/secure-contact-lambda.yaml
@@ -186,7 +186,7 @@ Resources:
         Bucket: !Ref ArtifactBucket
         Key: !Sub ${Stack}/${Stage}/${App}/lambda.zip
       Runtime: python3.7
-      Handler: pgp_listing
+      Handler: pgp_listing.lambda_handler
       Environment:
         Variables:
           STAGE: !Ref Stage

--- a/cloudformation/secure-contact-lambda.yaml
+++ b/cloudformation/secure-contact-lambda.yaml
@@ -1,0 +1,205 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Run the SecureContact Lambda in AWS
+
+Parameters:
+  ArtifactBucket:
+    Description: Name of the S3 bucket where the artifact is located
+    Type: String
+
+  DataBucketName:
+    Description: Name to use for the private S3 bucket where we upload data
+    Type: String
+
+  PublicBucketName:
+    Description: Name to use for the public S3 bucket that will serve content
+    Type: String
+
+  Stage:
+    Description: Application stage
+    Type: String
+    AllowedValues:
+    - PROD
+    - CODE
+    - DEV
+    Default: PROD
+
+  App:
+    Description: Application name
+    Type: String
+    Default: secure-contact
+
+  Stack:
+    Description: Application stack
+    Type: String
+    Default: secure-contact
+
+  AccessRestrictionCidr:
+    Description: A CIDR from which access is allowed
+    AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+    ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
+    Type: String
+
+Resources:
+
+# ----------------------- #
+#  S3 BUCKETS FOR APP     #
+# ----------------------- #
+
+  DataBucket:
+    Type: AWS::S3::Bucket
+    DependsOn: BucketPermission
+    DeletionPolicy: Retain
+    Properties:
+      AccessControl: Private
+      BucketName: !Ref DataBucketName
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Function: !GetAtt SecureContactWatcher.Arn
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
+  DataBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: DataBucket
+      PolicyDocument: 
+        Statement: 
+        - Action:
+          - s3:ListBucket
+          - s3:GetObject
+          Effect: Allow
+          Resource:
+            - !Sub arn:aws:s3:::${DataBucket}
+            - !Sub arn:aws:s3:::${DataBucket}/*
+          Principal:
+            AWS: 
+            - !Ref AWS::AccountId
+
+  PublicBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: PublicRead
+      BucketName: !Ref PublicBucketName
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 28
+            Status: Enabled
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: 404.html
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
+  PublicBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: PublicBucket
+      PolicyDocument:
+        Statement:
+        - Action:
+          - s3:GetObject
+          Effect: Allow
+          Resource:
+            - !Sub arn:aws:s3:::${PublicBucket}/*
+          Principal: "*"
+          Condition:
+            IpAddress:
+              aws:SourceIp: !Ref AccessRestrictionCidr
+
+# ----------------------- #
+#  SECURE CONTACT LAMBDA  #
+# ----------------------- #
+
+  BucketPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref SecureContactWatcher
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref "AWS::AccountId"
+      SourceArn: !Sub arn:aws:s3:::${DataBucketName}
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: {Service: [lambda.amazonaws.com]}
+            Action: ['sts:AssumeRole']
+      Path: /
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      Policies:
+        - PolicyName: data-bucket-read
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - !Sub arn:aws:s3:::${DataBucketName}
+                  - !Sub arn:aws:s3:::${DataBucketName}/*
+        - PolicyName: public-bucket-upload
+          PolicyDocument:
+            Statement:
+              # grant access to the S3 bucket that will hold the website contents
+              - Effect: Allow
+                Resource: !Sub arn:aws:s3:::${PublicBucketName}
+                Action:
+                  - s3:ListBucket
+              - Effect: Allow
+                Resource: !Sub arn:aws:s3:::${PublicBucketName}/*
+                Action:
+                  - s3:PutObject
+                  - s3:DeleteObject
+
+  SecureContactWatcher:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Generate static files when keys are added
+      FunctionName: !Sub ${App}-${Stage}
+      Role: !GetAtt LambdaExecutionRole.Arn
+      CodeUri: 
+        Bucket: !Ref ArtifactBucket
+        Key: !Sub ${Stack}/${Stage}/${App}/lambda.zip
+      Runtime: python3.7
+      Handler: app.pgp_listing
+      Environment:
+        Variables:
+          STAGE: !Ref Stage
+          DATA_BUCKET_NAME: !Ref DataBucketName
+          PUBLIC_BUCKET_NAME: !Ref PublicBucketName
+      Timeout: 300
+      ReservedConcurrentExecutions: 1
+      Events:
+        CheckStatusEvent:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 day) 
+      Tags:
+        Stack: !Ref Stack
+        Stage: !Ref Stage
+        App: !Ref App

--- a/pgp_listing.py
+++ b/pgp_listing.py
@@ -68,7 +68,9 @@ def render_page(groups: List[Group]):
 
 if __name__ == '__main__':
 
-    all_entries = pgp_manager.main()
+    session = pgp_manager.create_session()
+
+    all_entries = pgp_manager.get_all_entries(session)
 
     enhanced_entries = [enhance_entry(entry) for entry in all_entries]
     all_groups = create_groups(sort_entries(enhanced_entries))
@@ -78,7 +80,7 @@ if __name__ == '__main__':
         shutil.rmtree('./build')
 
     print('copying static assets')
-    shutil.copytree('./static', './build')
+    shutil.copytree('./static', './build/static')
 
     print('Creating templates')
     text_file = open("build/index.html", "w")

--- a/pgp_manager.py
+++ b/pgp_manager.py
@@ -30,11 +30,6 @@ def parse_name(key: str) -> str:
     return key.replace('PublicKeys/', '').replace('.pub.txt', '')
 
 
-# TODO: can we autogenerate the fingerprint?
-def generate_fingerprint(s3_client, bucket: str, name: str) -> str:
-    return ''
-
-
 # Not all public keys will have a corresponding fingerprint
 def fetch_fingerprint(s3_client, bucket: str, name: str) -> Union[None, str]:
     key = f'Fingerprints/{name}.fpr.txt'
@@ -152,8 +147,3 @@ if __name__ == "__main__":
         PUBLIC_BUCKET_NAME = config['PUBLIC_BUCKET_NAME']
         AWS_PROFILE = config['AWS_PROFILE']
 
-    aws_session = create_session(AWS_PROFILE)
-    all_entries = get_all_entries(aws_session, DATA_BUCKET_NAME)
-
-    copy_keys_to_public_bucket(aws_session, DATA_BUCKET_NAME, PUBLIC_BUCKET_NAME, all_entries)
-    upload_files(aws_session, PUBLIC_BUCKET_NAME, './build')

--- a/pgp_manager.py
+++ b/pgp_manager.py
@@ -98,6 +98,12 @@ def get_content_type(filename: str) -> str:
         return 'text/css'
 
 
+def upload_html(session: Session, bucket: str, key: str, body: str) -> None:
+    client = session.client('s3')
+    content_type = 'text/html'
+    client.put_object(Body=body, Bucket=bucket, Key=key, ContentType=content_type)
+
+
 def upload_files(session: Session, bucket: str, path: str) -> None:
     s3 = session.resource('s3')
     bucket = s3.Bucket(bucket)

--- a/templates/public/pgp-listing.html
+++ b/templates/public/pgp-listing.html
@@ -59,7 +59,7 @@
                 {% for entry in group.entries %}
                     <li class="collection-item js-entry">
                         <div class="row">
-                            <div class="col s6 entry__name js-name">{{ entry.name }}</div>
+                            <div class="col s6 entry__name js-name">{{ entry.other_names }} {{ entry.last_name }}</div>
                             <div class="col s6"><a class="entry__link" href='{{ entry.publickey }}'>Public Key</a></div>
                             <div class="col s12 fingerprint__label">Fingerprint: <span class="fingerprint">{{ entry.fingerprint }}</span></div>
                         </div>

--- a/tests/pgp_listing_test.py
+++ b/tests/pgp_listing_test.py
@@ -16,56 +16,57 @@ class TestSortingEntries(unittest.TestCase):
         self.assertEqual('6FD2 E4C9 71AD B9BB 1573  85EA 383B C341 85FB BD09', expected)
 
     def test_enhance_entry(self):
-        result = enhance_entry(Entry('kate whalen', 'whalen pk', self.raw_fingerprint))
+        result = enhance_entry(Entry('Kate Whalen', 'whalen pk', self.raw_fingerprint))
 
-        self.assertEqual(result.name, 'Kate Whalen')
+        self.assertEqual(result.other_names, 'Kate')
+        self.assertEqual(result.last_name, 'Whalen')
         self.assertEqual(result.fingerprint, '6FD2 E4C9 71AD B9BB 1573  85EA 383B C341 85FB BD09')
 
     def test_sort_entries(self):
         result = sort_entries([
-            Entry('Sam Cutler', 'cutler pk', 'cutler fp'),
-            Entry('David Blishen', 'blishen pk', 'blishen fp'),
-            Entry('Kate Whalen', 'whalen pk', 'whalen fp'),
-            Entry('Michael Barton', 'barton pk', 'barton fp')
+            EnhancedEntry('Sam', 'Cutler', 'cutler pk', 'cutler fp'),
+            EnhancedEntry('David', 'Blishen', 'blishen pk', 'blishen fp'),
+            EnhancedEntry('Kate', 'Whalen', 'whalen pk', 'whalen fp'),
+            EnhancedEntry('Michael', 'Barton', 'barton pk', 'barton fp')
         ])
         expected = {
             'B': [
-                Entry('David Blishen', 'blishen pk', 'blishen fp'),
-                Entry('Michael Barton', 'barton pk', 'barton fp')
+                EnhancedEntry('David', 'Blishen', 'blishen pk', 'blishen fp'),
+                EnhancedEntry('Michael', 'Barton', 'barton pk', 'barton fp')
             ],
             'C': [
-                Entry('Sam Cutler', 'cutler pk', 'cutler fp')
+                EnhancedEntry('Sam', 'Cutler', 'cutler pk', 'cutler fp'),
             ],
             'W': [
-                Entry('Kate Whalen', 'whalen pk', 'whalen fp')
+                EnhancedEntry('Kate', 'Whalen', 'whalen pk', 'whalen fp'),
             ]
         }
         self.assertEqual(result, expected)
 
-    def test_create_groups(self):
-        result = list(create_groups({
+    def test_create_ordered_groups(self):
+        result = list(create_ordered_groups({
             'B': [
-                Entry('David Blishen', 'blishen pk', 'blishen fp'),
-                Entry('Michael Barton', 'barton pk', 'barton fp')
+                EnhancedEntry('David', 'Blishen', 'blishen pk', 'blishen fp'),
+                EnhancedEntry('Michael', 'Barton', 'barton pk', 'barton fp')
             ],
             'C': [
-                Entry('Sam Cutler', 'cutler pk', 'cutler fp')
+                EnhancedEntry('Sam', 'Cutler', 'cutler pk', 'cutler fp'),
             ],
             'W': [
-                Entry('Kate Whalen', 'whalen pk', 'whalen fp')
+                EnhancedEntry('Kate', 'Whalen', 'whalen pk', 'whalen fp'),
             ]
         }))
 
         self.assertEqual(result[0], Group('B', [
-                Entry('David Blishen', 'blishen pk', 'blishen fp'),
-                Entry('Michael Barton', 'barton pk', 'barton fp')
+                EnhancedEntry('Michael', 'Barton', 'barton pk', 'barton fp'),
+                EnhancedEntry('David', 'Blishen', 'blishen pk', 'blishen fp')
             ]))
 
         self.assertEqual(result[1], Group('C', [
-                Entry('Sam Cutler', 'cutler pk', 'cutler fp')
+                EnhancedEntry('Sam', 'Cutler', 'cutler pk', 'cutler fp'),
             ]))
         self.assertEqual(result[2], Group('W', [
-                Entry('Kate Whalen', 'whalen pk', 'whalen fp')
+                EnhancedEntry('Kate', 'Whalen', 'whalen pk', 'whalen fp'),
             ]))
 
 


### PR DESCRIPTION
#### 👉 Create separate CFN that can create a lambda

The Lambda is triggered by uploading files to the data bucket in S3. So the site should auto-update just like magic! If we do a batch upload of keys we only want to fire the Lambda once so `ReservedConcurrentExecutions` is set to 1.

The lambda has a `CheckStatusEvent` will run once a day even if there have been no keys uploaded to the data bucket. 

There is a lifecycle rule on the public bucket to account for when keys are deleted. This allows the Lambda to only need to put items to the public bucket, rather than validate that all the current keys and fingerprints are valid. The `ExpirationInDays` is currently 28 which can probably be significantly reduced once the site is ready for PROD. 

If we want to remove a key, we will only have to delete the key and fingerprint from the data bucket. 

#### 👉 Reuse single session, write methods for upload to S3 and handle index page upload to S3

We only need one session with the AWS SDK that we can then use to get clients or resources.
The scripts can now use the templates and data from S3 to generate the index page.
We need to set the content type to `text/html` when uploading as it defaults to `binary/octet-stream`

#### 👉 Dockerfile and script updates to include full AWS functionality

Dockerfile may be a mistake, but I have also been experimenting with running apps in Docker. Python makes setting up the DEV and PROD environments slightly frustrating, and Docker might be something worth adopting if we end up managing a lot of Python apps.

#### 👉 Write the lambda handler

This is referenced in the CloudFormation template under `LambdaConfigurations` and is what will be invoked when the lambda is triggered. 