### PR TITLE
Switch to building pages and uploading to S3

### DIFF
--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -165,7 +165,9 @@ Resources:
               Resource: "*"
             # allow service to update the website configuration
             - Effect: Allow
-              Resource: !Sub arn:aws:s3:::${PublicBucket}
+              Resource:
+                - !Sub arn:aws:s3:::${PublicBucket}
+                - !Sub arn:aws:s3:::${PublicBucket}/*
               Action:
                 - S3:PutBucketWebsite
                 - S3:PutObject
@@ -261,17 +263,20 @@ Resources:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev
 
-          adduser --system --home /secure-contact --disabled-password secure-contact
+          echo ${Stage} > /etc/stage
 
-        # Get repo and build pages
+          adduser --home /secure-contact --disabled-password secure-contact
 
-          export STAGE="${Stage}"
-          export STACK="${Stack}"
-          export APP="${App}"
-          export REGION="${AWS::Region}"
+          git clone https://github.com/guardian/secure-contact /secure-contact
+          pip3 install -r /secure-contact/requirements.txt
 
-        # Start services and application
+          touch /secure-contact/cron-lastrun.log
+          echo '00 * * * *python3 /secure-contact/monitor.py > /secure-contact/cron-lastrun.log 2>&1' | crontab -u secure-contact -
+
+          chown -R secure-contact /secure-contact
+
           service tor start
+
 
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -168,6 +168,7 @@ Resources:
               Resource: !Sub arn:aws:s3:::${PublicBucket}
               Action:
                 - S3:PutBucketWebsite
+                - S3:PutObject
 
   # Minimal policy to run commands via ssm and use ssm-scala
   SSMRunCommandPolicy:

--- a/securedrop.py
+++ b/securedrop.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+env = Environment(
+    loader=FileSystemLoader(THIS_DIR + '/templates/public'),
+    trim_blocks=True,
+    autoescape=select_autoescape(['html', 'xml'])
+)
+
+
+def render_page(securedrop_url: str, path: str, passes_healthcheck: bool):
+    root_template = env.get_template('securedrop.html')
+    return root_template.render(
+        securedrop_url=securedrop_url,
+        path=path,
+        passes_healthcheck=passes_healthcheck
+    )
+
+
+def build_pages(securedrop_url: str, stage: str):
+    # routing in Fastly requires the PROD pages to include securedrop/ before links to assets
+    path = 'securedrop/' if stage == 'PROD' else ''
+
+    if os.path.exists('./build'):
+        shutil.rmtree('./build')
+    os.makedirs('./build')
+
+    passed = render_page(securedrop_url, path=path, passes_healthcheck=True)
+    failed = render_page(securedrop_url, path=path, passes_healthcheck=False)
+
+    index = open("build/index.html", "w")
+    maintenance = open("build/maintenance.html", "w")
+
+    index.write(passed)
+    maintenance.write(failed)
+    index.close()
+    maintenance.close()
+
+
+if __name__ == '__main__':
+    build_pages('33y6fjyhs3phzfjj.onion', stage='DEV')
+    shutil.copytree('./static', './build/static')
+

--- a/templates/public/securedrop.html
+++ b/templates/public/securedrop.html
@@ -61,7 +61,7 @@
             For security reasons, we advise you, especially if you are uploading documents, not to use your home or work network, but instead to use a public Wi-Fi network in an  area where your screen is not visible to security cameras. Alternately, you can start up your computer from a USB key loaded with the Tails secure operating system, which is available at <a href="https://tails.boum.org/">https://tails.boum.org</a> and includes the Tor web browser.
           </li>
           <li class="gu-text">
-            Once you launch the Tor browser, copy and paste the URL <span class="onion-url">33y6fjyhs3phzfjj.onion</span> into the Tor address bar. When the page loads, you will find further instructions on how to submit files and messages to the Guardian.
+            Once you launch the Tor browser, copy and paste the URL <span class="onion-url">{{ securedrop_url }}</span> into the Tor address bar. When the page loads, you will find further instructions on how to submit files and messages to the Guardian.
           </li>
 
           <li class="gu-text">


### PR DESCRIPTION
#### 👉 Build SecureDrop pages and enable monitor upload

Routing in Fastly requires the PROD pages to include `securedrop/` before links to assets. 
 Setting the path prefix based on the stage seems like a nice approach since this will allow the page to link assets correctly when running as DEV or CODE:

```python
path = 'securedrop/' if stage == 'PROD' else ''
```

#### 👉 Remove hardcoded onion url from template

Since we are fetching the `securedrop_url` from AWS parameter store each time the script runs anyway, and the monitor service is generating the html, we can actually pass the securedrop_url into the template as a parameter! 

```html
Once you launch the Tor browser, copy and paste the URL <span class="onion-url">{{ securedrop_url }}</span>
```

This means we can change it within an hour without requiring a code change or redeploy. 🧙‍♀️✨

#### 👉 Added some TODOs into the monitor script

Production Ready™️ but a Work In Progress...
So here is hoping we can come back to some of the TODOs