### PR TITLE
Fix website update, switch to Pipenv, change how Tor installs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,36 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+awscli = "==1.16.209"
+boto3 = "==1.9.131"
+botocore = "==1.12.199"
+certifi = "==2019.3.9"
+chardet = "==3.0.4"
+click = "==7.0"
+colorama = "==0.3.9"
+docutils = "==0.14"
+idna = "==2.8"
+itsdangerous = "==1.1.0"
+jmespath = "==0.9.4"
+pyasn1 = "==0.4.6"
+python-dateutil = "==2.8.0"
+requests = "==2.21.0"
+rsa = "==3.4.2"
+s3transfer = "==0.2.0"
+six = "==1.12.0"
+urllib3 = "==1.24.2"
+watchtower = "==0.7.3"
+Flask = "==1.1.1"
+Jinja2 = "==2.10.1"
+MarkupSafe = "==1.1.1"
+PySocks = "==1.7.0"
+PyYAML = "==5.1"
+Werkzeug = "==0.15.5"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,274 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "ff8d93204a12b1e5aef45c9ae32a524e3fa54b745d1e002fdbd86c3407ebe914"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "awscli": {
+            "hashes": [
+                "sha256:68dbc2170b7b9c87cbe1ca9f6b3a68ca07172cef77fa2d48295d08e19ddbe7af",
+                "sha256:6b4491d2e2e5676f530c290899602ed03711f3ec9a5305edd130e0ab6bbf7423"
+            ],
+            "index": "pypi",
+            "version": "==1.16.209"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:c2816b25fdd792d759ef4d19b6dd551ef93232992d55fbf87307a71ab62ee159",
+                "sha256:f6f58cf19cc99bc90f1c57dcddf6fdf97d63e152263fc32bfa1d45ee4b278009"
+            ],
+            "index": "pypi",
+            "version": "==1.9.131"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:25d87047241b7b775443570c0e790ca952f9f7491d4d6472430a4b006383a257",
+                "sha256:e4729c1acaa936d4c5c948a18d279f92bbf61fad9b5fb03942c753ec405e427d"
+            ],
+            "index": "pypi",
+            "version": "==1.12.199"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "index": "pypi",
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "index": "pypi",
+            "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "index": "pypi",
+            "version": "==7.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
+                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+            ],
+            "index": "pypi",
+            "version": "==0.3.9"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "index": "pypi",
+            "version": "==0.14"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
+            ],
+            "index": "pypi",
+            "version": "==1.1.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "index": "pypi",
+            "version": "==2.8"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+            ],
+            "index": "pypi",
+            "version": "==2.10.1"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+            ],
+            "index": "pypi",
+            "version": "==0.9.4"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+            ],
+            "index": "pypi",
+            "version": "==1.1.1"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:0c444a3482c5f5c7fab93567761324f77045ede002362171e12acdd400ea50e0",
+                "sha256:27e919f274d96829d9c78455eacf6a2253c9fd44979e5f880b672b524161366d",
+                "sha256:3bb81821d47b17146049e7574ab4bf1e315eb7aead30efe5d6a9ca422c9710be",
+                "sha256:3f8b11ba9fde9aeb56882589896cf9c7c8f4d5630f5e83abec1d80d1ef37b28b",
+                "sha256:40f307cb9e351bf54b5cf956a85e02a42d4f881dac79ce7d0b736acb2adab0e5",
+                "sha256:54734028b18e1d625a788d9846479ce088f10015db9ffb1abdd406d82b68b600",
+                "sha256:5616c045d1eb934fecc0162bc2b9bd2c8935d4a3c4642c3ccd96fb1528b1f218",
+                "sha256:5eb6dbc1191dc8a18da9d3ee4c3133909e3cfd0967d434dee958e737c1ca0bb7",
+                "sha256:72f5f934852f4722e769ec9a4dd20d6fa206a78186bab2aadf27753a222892f6",
+                "sha256:86ddc0f9a9062f111e70de780c5eb6d5d726f44809fafaa0af7a534ed66fc7c1",
+                "sha256:b17f6696f920dc712a4dc5c711b1abd623d80531910e1455c70a6cb85ffb6332",
+                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86",
+                "sha256:f8dda822e63df09237acd8f88940c68c1964076e5d9a906cbf385d71ec1a4006"
+            ],
+            "index": "pypi",
+            "version": "==0.4.6"
+        },
+        "pysocks": {
+            "hashes": [
+                "sha256:15d38914b60dbcb231d276f64882a20435c049450160e953ca7d313d1405f16f",
+                "sha256:32238918ac0f19e9fd870a8692ac9bd14f5e8752b3c62624cda5851424642210",
+                "sha256:d9031ea45fdfacbe59a99273e9f0448ddb33c1580fe3831c1b09557c5718977c"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "index": "pypi",
+            "version": "==2.8.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+            ],
+            "index": "pypi",
+            "version": "==5.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
+                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
+            ],
+            "index": "pypi",
+            "version": "==3.4.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
+                "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "index": "pypi",
+            "version": "==1.12.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+            ],
+            "index": "pypi",
+            "version": "==1.24.2"
+        },
+        "watchtower": {
+            "hashes": [
+                "sha256:715e2480633490719280a89bfec60fb383510fe577644418ccb6b980e55f9826",
+                "sha256:82eee8350999825c84bbfc305406a483304d4a6c848a53ec84b151e95364f8d2"
+            ],
+            "index": "pypi",
+            "version": "==0.7.3"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4",
+                "sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6"
+            ],
+            "index": "pypi",
+            "version": "==0.15.5"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -4,113 +4,84 @@
 
 > ~ Terry Pratchett
 
-Scripts for building and running the Guardian's PGP contact and SecureDrop pages
+Automation and tooling for the [PGP contact](https://www.theguardian.com/pgp) and [SecureDrop status](https://www.theguardian.com/securedrop) pages of The Guardian.
 
-## Overview
 
-### Secure Contact Monitor
+## Secure Contact Monitor
 
-Secure Contact Monitor (SCM) performs status monitoring of our onion website and updates our status page accordingly.
+Secure Contact Monitor (SCM) performs status monitoring of our onion site and updates our status page accordingly.
 
 The monitor script attempts to reach our onion site five times, with a 60 second interval between each attempt. The timeouts and sleep are quite generous, which gives the Tor network the benefit of the doubt.
 
 SCM will send notifications via Hangouts Chat and/or email. The channel it messages is determined by the webhook URL that is stored in AWS parameter store.
 
-Most of the configuration, including the Onion URL, is stored in AWS Parameter Store and fetched each time the script is run.
+Most of the configuration, including the Onion URL, is stored in AWS Parameter Store and fetched every time the script runs.
 
-### Notifications and alerts
+### Local Development
 
-TODO: document monitor history and how the application uses DynamoDB
-
-## Contributing
-
-### Python and virtualenv
-
-This project is using Python 3.
-
-#### 1. Install Python
-
-MacOS users can use homebrew to install Python 3:
-
-```bash
-brew install python3
+Clone the repository and move into the directory:
+```
+git clone https://github.com/guardian/secure-contact.git
+cd secure-contact/
 ```
 
-#### 2. Install and activate virtualenv
+#### 1. Install and Configure Tor
 
-It is a good idea to use virtualenv with Python, this can be done with Pip:
+For the healthchecks to work, the machine needs to be running Tor. Even though Tor Browser comes with a regular Tor, it will only run while Tor Browser is open. Therefore, Tor should be installed as a command line tool.
 
-```bash
-pip3 install virtualenv
-```
-
-If you are setting up this project for the first time you will need to create a virtualenv.
-From the root directory of the project run:
+MacOS users can use Homebrew to install Tor:
 
 ```bash
-virtualenv venv
-```
-
-Once that is done, this command will activate virtualenv:
-
-```bash
-source venv/bin/activate
-```
-
-More details on virtual environments can be found here: https://docs.python-guide.org/dev/virtualenvs/
-
-When you are finished with the virtualenv enter `deactivate` in the terminal to return to the default Python interpreter of the system. However, keep the virtualenv running while completing the remaining steps!
-
-#### 3. Install packages
-
-With your virtualenv active, you should be in the directory where requirements.txt is located.
-
-For installing the required packages run:
-
-```bash
-pip3 install -r requirements.txt
-```
-
-### Running locally
-
-#### DynamoDB
-
-Secure Contact Monitor uses DynamoDB to persist some information. Therefore to run it locally you will need to make sure you have DynamoDB running. [You can download DynamoDB to run as a local jar from the AWS website](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html).
-
-To run DynamoDB for development, execute the following:
-
-```bash
-java -Djava.library.path=~/etc/DynamoDBLocal_lib -jar ~/etc/DynamoDBLocal.jar -sharedDb -inMemory
-
-```
-
-You'll also need to set up the required tables. The easiest way to do this is to run the test suite that exists for this purpose:
-
-```bash
-python3 tests/test_database.py
-```
-
-Since this runs an in-memory version of DynamoDB, you'll need to set the tables up again each time you restart DynamoDB.
-
-#### Tor
-
-For the healthchecks to pass, the machine needs to be running Tor. Even though Tor Browser comes with a regular Tor, it will only run as long as you keep Tor Browser open.
-
-MacOS users can use homebrew to install Tor as a command line tool:
-
-```bash
-
 brew install tor
 ```
 
-The `.sample` extension will then need to be removed from the `torrc` configuration file. The file should be in your   /usr/local/etc/tor/ directory.
+The `.sample` extension will then need to be removed from the `torrc` configuration file. If you installed Tor using Homebrew The file should be in your `/usr/local/etc/tor/` directory.
 
-More instructions are available on [The Tor Project website](https://2019.www.torproject.org/docs/tor-doc-osx.html.en).
+More instructions are available on [The Tor Project site](https://2019.www.torproject.org/docs/tor-doc-osx.html.en).
 
-While developing locally, use a separate terminal window to run:
+#### 2. Install Python and Pipenv
+
+This project is using Python 3 and [Pipenv](https://pypi.org/project/pipenv/). Pipenv automatically creates and manages a virtualenv for  projects, as well as adds/removes packages from your Pipfile as you install/uninstall packages.
+
+MacOS users can use Homebrew to install both:
+
+```bash
+brew install python3 pipenv
+```
+
+If you install Python via Homebrew you should now also have pip installed. If you are on Linux and installed with an OS package manager, you may have to install pip separately.
+
+#### 3. Install dependencies with Pipenv
+
+It is a good idea to use a virtual environment with Python; this project uses Pipenv.
+From the `secure-contact/` directory, use pipenv to install the required packages and start the virtual environment:
+
+```bash
+pipenv install && pipenv shell
+```
+
+If you run into any issues setting up Python and pipenv, this guide may help: https://docs.python-guide.org/dev/virtualenvs/
+
+Keep the virtual environment running while completing the remaining steps! If you need to terminate the virtual environment, enter `deactivate` in the terminal. This will return you to the default Python interpreter of the system.
+
+#### Running Locally
+
+start Tor running in a terminal:
 
 ```bash
 tor
+```
+
+In another terminal window, navigate to the secure-contact directory and start the virtual environment if it is not already running:
+
+```bash
+pipenv shell
+```
+
+You should now be able to run the modules and tests. To run the healthcheck locally use:
+
+```bash
+python3 -m src.monitor
 ```
 
 ## Validation
@@ -119,6 +90,12 @@ The following command will run the Python tests:
 
 ```bash
 python -m unittest discover -s tests
+```
+
+It is possible to specify a single test case to run, for example:
+
+```bash
+python -m unittest tests.test_database
 ```
 
 

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -254,6 +254,10 @@ Resources:
           - ssm:ListInstanceAssociations
           - ssm:DescribeInstanceProperties
           - ssm:DescribeDocumentParameters
+          - ssmmessages:CreateControlChannel
+          - ssmmessages:CreateDataChannel
+          - ssmmessages:OpenControlChannel
+          - ssmmessages:OpenDataChannel
       Roles:
       - !Ref SecureContactInstanceRole
 
@@ -287,11 +291,6 @@ Resources:
         ToPort: 80
         SourceSecurityGroupId:
           Ref: LoadBalancerSecurityGroup
-      # allow SSH access to specified IP range
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: !Ref SSHAccessCidr
       SecurityGroupEgress:
       # allow instance to make http requests
       - IpProtocol: tcp

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -330,14 +330,31 @@ Resources:
 
           echo ${Stage} > /etc/stage
 
+          # install tor according to the offical guide: https://2019.www.torproject.org/docs/debian.html.en
+          apt install -y apt-transport-https
+          echo "deb https://deb.torproject.org/torproject.org bionic main" | tee -a /etc/apt/sources.list.d/tor.list
+          curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
+          gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
+          apt update
+          apt install -y tor deb.torproject.org-keyring
+
+          # Check that tor is running before we proceed
+          while true
+          do
+            sleep 1
+            curl -s --head --socks5-hostname 127.0.0.1:9050 https://check.torproject.org
+            CURL_RC=$?
+            [ $CURL_RC -eq 0 ] && break
+          done
+
           # install application
           mkdir /secure-contact
           git clone https://github.com/guardian/secure-contact /secure-contact
-          pip3 install -r /secure-contact/requirements.txt
 
-          # start tor and run monitor
-          service tor start
-          cd /secure-contact && python3 monitor.py
+          # install python packages and run monitor once
+          cd /secure-contact
+          pipenv install
+          python3 -m src.monitor
 
           # fix permissions
           chown -R www-data /secure-contact/
@@ -364,10 +381,10 @@ Resources:
 
           nginx -s reload
 
-          # schedule monitoring service
+          # schedule monitoring service to run on every hour
           touch /secure-contact/cron-lastrun.log
           chown www-data /secure-contact/cron-lastrun.log
-          echo '00 * * * * cd /secure-contact && python3 monitor.py > /secure-contact/cron-lastrun.log 2>&1' | crontab -u www-data -
+          echo '00 * * * * cd /secure-contact && python3 -m src.monitor > /secure-contact/cron-lastrun.log 2>&1' | crontab -u www-data -
 
 
   AutoscalingGroup:

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -161,9 +161,10 @@ def run(session: Session, config: Dict[str, str]):
         logger.info(f'Healthcheck: unable to reach site on attempt {attempts}')
         time.sleep(60)
     else:
+        logger.info('Healthcheck: failed healthcheck')
+        upload_website_index(session, config, False)
         send_message(config, passed=False)
         send_failure_email(session, config)
-        logger.info('Healthcheck: failed healthcheck')
 
 
 if __name__ == '__main__':

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -75,8 +75,7 @@ def send_email(session: Session, config: Dict[str, str], message: Dict):
     except ClientError as e:
         logger.error(e.response['Error']['Message'])
     else:
-        logger.info('Email sent! Message ID:')
-        logger.info(response['MessageId'])
+        logger.info(f'Email sent! Message ID: {response["MessageId"]}')
 
 
 def generate_message(card_title: str, card_subtitle: str, message_text: str) -> Dict:


### PR DESCRIPTION
## What does this change?

#### 👉  Actually update the S3 contents when healthcheck fails

Mea Culpa;  I removed the all important call to `upload_website_index` when making some changes a while ago. This only affected updates when the hidden site was unavailable. Since the site did not had any availability issues until [the recent Tor outage](https://www.expressvpn.com/blog/tor-network-outage/) I did not notice the issue.

#### 👉  Update SSM policy and remove SSH ingress

For a long time at The Guardian it has been possible to SSH without opening up port 22, thanks to [SSM-Scala!](https://github.com/guardian/ssm-scala)

Along with removing the requirement to have port 22 open, SSM-Scala also provides visibility into which instances have been accessed, and when.

#### 👉  Switch to using Pipenv and update README

[Pipenv](https://pypi.org/project/pipenv/) automatically creates and manages a virtualenv for  projects, as well as adds/removes packages from your Pipfile as you install/uninstall packages.

The README has been improved and now explains how to use Pipenv for development work.

This also switches to using Pipenv to install python packages on the EC2 instances.

#### 👉  Update LaunchConfig and how we install Tor

Tor is now installed and started as a background service using the steps recommended by the [Tor Project ubuntu guide](https://2019.www.torproject.org/docs/debian.html.en). This also adds a check to the UserData that Tor is running (on port 9050) before proceeding with the instance launch.
