### PR TITLE
Fix the expected text for the SecureDrop healthcheck

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -72,7 +72,7 @@ def send_request(onion_address: str) -> Optional[requests.Response]:
 
 
 def healthcheck(response: Optional[requests.Response]) -> bool:
-    expected_text = 'SecureDrop | Protecting Journalists and Sources'
+    expected_text = 'The Guardian | SecureDrop'
     if response:
         logger.info(f'response status code: {response.status_code}')
         if response.status_code == 200 and expected_text in response.text:


### PR DESCRIPTION
A SecureDrop version update caused a change in the text on the onion site at the beginning of 2021.
This change ensures that healthcheck actually passes. 👏

We might want to reevaluate how we pass/fail healthcheck if the text comparison is too fragile and this issue occurs again.
Is a 200 response code enough?

