### PR TITLE
Various SecureDrop monitoring improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,17 @@ python -m unittest tests.test_database
 
 The Secure Contact Monitor service is an EC2 instance running in AWS. The CloudFormation template can be found in this repository and will also create a load balancer and autoscaling group (ASG).
 
-To release the latest version of master to a stage, login to the AWS console and terminate the currently running instance. Once the ASG healthchecks fail, the ASG will launch a new instance using the launch config in the CloudFormation template.
+When an instance launches it will perform the status check and update the status page in S3. Subsequent checks are performed via a cron job that is configured in the launch config UserData.
 
-The status page will remain available during the replacement since the page is served from an S3 bucket. While the new instance is launching it will perform the status check and update the status page in S3.
+To manually run the monitor script, either use [SSM-Scala](https://github.com/guardian/ssm-scala) or start a session in AWS Systems Manager and run the following command:
+
+```bash
+cd /secure-contact && sudo -u www-data python3 -m src.monitor
+```
+
+To release the latest version of the service, consider using [Amiup](https://github.com/guardian/amiup) in yolo mode so that the AMI can be updated at the same time.
+
+Alternatively, login to the AWS console and terminate the currently running instance. Once the ASG healthchecks fail, the ASG will launch a new instance using the launch config in the CloudFormation template. The status page will remain available during the replacement since the page is served from an S3 bucket.
 
 
 ## TODO:

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -384,7 +384,7 @@ Resources:
           # schedule monitoring service to run on every hour
           touch /secure-contact/cron-lastrun.log
           chown www-data /secure-contact/cron-lastrun.log
-          echo '00 * * * * cd /secure-contact && python3 -m src.monitor > /secure-contact/cron-lastrun.log 2>&1' | crontab -u www-data -
+          echo '*/20 * * * * cd /secure-contact && python3 -m src.monitor > /secure-contact/cron-lastrun.log 2>&1' | crontab -u www-data -
 
 
   AutoscalingGroup:

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -331,19 +331,16 @@ Resources:
           echo ${Stage} > /etc/stage
 
           # install tor according to the offical guide: https://2019.www.torproject.org/docs/debian.html.en
-          apt update && apt install -y apt-transport-https
+          apt-get update && apt-get install -y apt-transport-https
           echo "deb https://deb.torproject.org/torproject.org bionic main" | tee -a /etc/apt/sources.list.d/tor.list
           curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
           gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
-          apt update && apt install -y tor deb.torproject.org-keyring
+          apt-get update && apt-get install -y tor deb.torproject.org-keyring
 
           # Check that tor is running before we proceed
-          while true
-          do
-            sleep 1
-            curl -s --head --socks5-hostname 127.0.0.1:9050 https://check.torproject.org
-            CURL_RC=$?
-            [ $CURL_RC -eq 0 ] && break
+          until $(curl -s -o /dev/null --head --fail --socks5-hostname 127.0.0.1:9050 https://check.torproject.org); do
+              printf '.'
+              sleep 3
           done
 
           # install application

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -331,12 +331,11 @@ Resources:
           echo ${Stage} > /etc/stage
 
           # install tor according to the offical guide: https://2019.www.torproject.org/docs/debian.html.en
-          apt install -y apt-transport-https
+          apt update && apt install -y apt-transport-https
           echo "deb https://deb.torproject.org/torproject.org bionic main" | tee -a /etc/apt/sources.list.d/tor.list
           curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
           gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
-          apt update
-          apt install -y tor deb.torproject.org-keyring
+          apt update && apt install -y tor deb.torproject.org-keyring
 
           # Check that tor is running before we proceed
           while true
@@ -353,13 +352,13 @@ Resources:
 
           # install python packages and run monitor once
           cd /secure-contact
-          pipenv install
+          pip3 install -r /secure-contact/requirements.txt
           python3 -m src.monitor
 
           # fix permissions
           chown -R www-data /secure-contact/
 
-          # nginx configuration
+          # add nginx configuration
           cd /etc/nginx/sites-available/
           cat <<SECURE_CONTACT_CONF > secure-contact
           server {


### PR DESCRIPTION
## What does this change?

#### 👉 Expand the README

Add notes on manually running the healthcheck and suggestion on how to perform AMI updates.

#### 👉 Change the cron schedule to every 20th minute

The healthcheck was previously running every hour on the hour. This PR changes the cron schedule so that the healthcheck also runs at the 20th and 40th minute and is therefore performed three times each hour (see image).

Increasing the frequency of the healthcheck improves the accuracy of the status page and gives us more information about the availability of the SecureDrop onion site.

#### 👉 Switch to apt-get and update before install

The apt commandline is designed for interactive use and therefore does not guarantee breaking backwards compatibility if a change is deemed beneficial for an end user.

> apt provides a high-level commandline interface for the package management system. It is intended as an end user interface and enables some options better suited for interactive usage by default compared to more specialized APT tools like apt-get and apt-cache.

http://manpages.ubuntu.com/manpages/hirsute/en/man8/apt.8.html

## Images

<img width="945" alt="Screenshot 2021-04-19 at 10 55 56" src="https://user-images.githubusercontent.com/8607683/115217880-da071780-a0fd-11eb-8d58-a419f372ba4d.png">

## Additional notes

This Cloudformation template has been applied to PROD 🚀 ✨ 