### PR TITLE
Fix font and accessibility issues

### DIFF
--- a/static/public.css
+++ b/static/public.css
@@ -8,6 +8,37 @@
     --sc-blue-1: #CCE8f7;
     --sc-blue-2: #C6E1Ef;
 }
+@font-face {
+	font-family: 'GH Guardian Headline';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf')
+			format('truetype');
+	font-weight: 700;
+	font-style: normal;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'GuardianTextSans';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf')
+			format('truetype');
+	font-weight: 400;
+	font-style: normal;
+	font-display: swap;
+}
+@font-face { 
+  font-family: 'GuardianTextEgyptian';
+  src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/full-autohinted/GuardianTextEgyptian-Regular.woff2') format('woff2'); 
+  font-weight: normal; 
+  font-style: normal; 
+}
+            
 
 .leira {
     display: none;
@@ -19,7 +50,7 @@
 
 body {
     margin: 0;
-    font-family: Guardian Text Egyptian Web,Georgia,serif;
+    font-family: GuardianTextEgyptian, Georgia, serif;
 }
 
 ol {
@@ -95,7 +126,7 @@ ol {
 .intro {
     margin-top: 2rem;
     font-weight: 700;
-    font-family: Guardian Headline,Georgia,serif;
+    font-family: 'GH Guardian Headline', Georgia, serif;
 }
 
 .intro__over-heading {
@@ -193,7 +224,7 @@ ol {
 .entry__fingerprint {
     margin-top: 12px;
     margin-bottom: 12px;
-    font-family: Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+    font-family: GuardianTextSans, 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
 
 .entry__link {
@@ -231,7 +262,7 @@ ol {
 
 .section-terms__text {
     font-size: .9rem;
-    font-family: Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+    font-family: GuardianTextSans, 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
 
 /* footer */
@@ -243,7 +274,7 @@ ol {
 .gu-copyright {
     font-size: .8rem;
     font-weight: 300;
-    font-family: Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+    font-family: GuardianTextSans, 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
 
 /* SecureDrop styles */

--- a/static/public.css
+++ b/static/public.css
@@ -7,38 +7,7 @@
 
     --sc-blue-1: #CCE8f7;
     --sc-blue-2: #C6E1Ef;
-}
-@font-face {
-	font-family: 'GH Guardian Headline';
-	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
-			format('woff2'),
-		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff')
-			format('woff'),
-		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf')
-			format('truetype');
-	font-weight: 700;
-	font-style: normal;
-	font-display: swap;
-}
-@font-face {
-	font-family: 'GuardianTextSans';
-	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
-			format('woff2'),
-		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
-			format('woff'),
-		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf')
-			format('truetype');
-	font-weight: 400;
-	font-style: normal;
-	font-display: swap;
-}
-@font-face { 
-  font-family: 'GuardianTextEgyptian';
-  src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/full-autohinted/GuardianTextEgyptian-Regular.woff2') format('woff2'); 
-  font-weight: normal; 
-  font-style: normal; 
-}
-            
+}           
 
 .leira {
     display: none;

--- a/static/public.css
+++ b/static/public.css
@@ -171,6 +171,15 @@ a {
     border-top: 1px solid #dcdcdc;
 }
 
+.filter__label-text {
+    position: absolute;
+    opacity: 0;
+    height: 0;
+    width: 0;
+    top: 0;
+    left: 0;
+}
+
 .filter__input {
     border-radius: 30px;
     padding: 10px 20px;

--- a/static/public.css
+++ b/static/public.css
@@ -58,6 +58,10 @@ ol {
     padding: 0;
 }
 
+a {
+  text-decoration: underline;
+}
+
 .header {
     display: flex;
     background: #052962;

--- a/templates/public/base.html
+++ b/templates/public/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html lang="en">
 
 <html>
   <head>

--- a/templates/public/pgp-listing.html
+++ b/templates/public/pgp-listing.html
@@ -39,7 +39,7 @@
     <section class='filter row require-js'>
         <div class="filter__container container gu-padding">
             <label for='filter'>
-                <span class="filter__label-text">Filter journalist names</span>
+                <span class="filter__label-text">Filter by name</span>
                 <input id='filter' name='filter' type='text' class='filter__input browser-default' onkeyup='filterNames()'
                     spellcheck="false" placeholder='Filter names...' />
             </label>

--- a/templates/public/pgp-listing.html
+++ b/templates/public/pgp-listing.html
@@ -39,6 +39,7 @@
     <section class='filter row require-js'>
         <div class="filter__container container gu-padding">
             <label for='filter'>
+                <span class="filter__label-text">Filter journalist names</span>
                 <input id='filter' name='filter' type='text' class='filter__input browser-default' onkeyup='filterNames()'
                     spellcheck="false" placeholder='Filter names...' />
             </label>


### PR DESCRIPTION
## What does this change?

- Add `@font-face` definitions for Guardian fonts (from [recommended `@font-face` rules](https://github.com/guardian/fonts#-recommended-font-face-rules))
- Override `materialize.css` styling to restore underlines in links 
- Add a visually hidden label to the filter field on the PGP page
- Add a lang attribute to page

## How can we measure success?

The `@font-face` rules allow the fonts to be loaded from a location that is shared across many Guardian products. This takes advantage of browser caching for performance optimisation, as well as improving visual consistency (see screenshots below)

`materialize.css` is applying `text-decoration: none` to all links. Removing the underline from links makes it hard for colour-blind users to see them.

Adding a label to "Filter names" field on the PGP page allows screen reader users to understand the purpose of the field. I have made the label visually hidden so as not to interfere with the original visual design.

Finally, adding a `lang` attribute to the `<html>` element ensures screen readers pronounce words correctly for the given language. 

## Images

### PGP

**Before**

<img width="1186" alt="Screenshot 2021-12-15 at 10 04 11" src="https://user-images.githubusercontent.com/5931528/146166184-0b0d66d3-2463-49bf-9844-507bd71008a5.png">

**After**

<img width="1249" alt="Screenshot 2021-12-15 at 10 04 32" src="https://user-images.githubusercontent.com/5931528/146166194-50e24d9e-30c4-4d93-bf4c-fd998558f79e.png">


### SecureDrop

**Before**

<img width="1203" alt="Screenshot 2021-12-15 at 10 14 47" src="https://user-images.githubusercontent.com/5931528/146167878-2e2dbbf8-69aa-43e1-b3e0-6c80c575f6d3.png">

**After**

![Screenshot 2021-12-15 at 10 15 04](https://user-images.githubusercontent.com/5931528/146167959-31fd1dbb-9191-4b35-a52f-ce588ab33ff8.png)



## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [x] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
