### PR TITLE
Upgrade secure-contact-monitor ubuntu distribution 

### DIFF
--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -330,8 +330,10 @@ Resources:
 
           echo ${Stage} > /etc/stage
 
-          # install tor according to the offical guide: https://2019.www.torproject.org/docs/debian.html.en
           apt-get update && apt-get install -y apt-transport-https
+
+          # restart tor service
+          sudo systemctl restart tor
 
           # Check that tor is running before we proceed
           until $(curl -s -o /dev/null --head --fail --socks5-hostname 127.0.0.1:9050 https://check.torproject.org); do

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -332,10 +332,6 @@ Resources:
 
           # install tor according to the offical guide: https://2019.www.torproject.org/docs/debian.html.en
           apt-get update && apt-get install -y apt-transport-https
-          echo "deb https://deb.torproject.org/torproject.org bionic main" | tee -a /etc/apt/sources.list.d/tor.list
-          curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
-          gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
-          apt-get update && apt-get install -y tor deb.torproject.org-keyring
 
           # Check that tor is running before we proceed
           until $(curl -s -o /dev/null --head --fail --socks5-hostname 127.0.0.1:9050 https://check.torproject.org); do


### PR DESCRIPTION
## What does this change?

Upgrading secure-contact-monitor to 20.04 Focal needed a few changes to the cloudformation userdata. The apt repo previously used applied to 18.04, so that and the step to install tor was removed as it was redundant. Installing the package also had the effect of starting the service, so a step to restart the service was added. 

## How to test

Deploy on secure-contact-CODE and wait for google chat message confirming connection to secure-contact. 

## How can we measure success?

Secure-contact-monitor runs on 20.04

