### PR TITLE
Human URL Cloudformation and pythoin fix

### DIFF
--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -209,6 +209,7 @@ Resources:
                 - ssm:GetParametersByPath
               Resource:
                 - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/securedrop-url
+                - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/securedrop-url-human                
                 - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/secure-contact/${Stage}/*
             # send email alerts from validated addresses
             - Effect: Allow

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -182,9 +182,10 @@ if __name__ == '__main__':
         'PRODMON_SENDER': fetch_parameter(SSM_CLIENT, f'/secure-contact/{STAGE}/prodmon-sender'),
         'PRODMON_RECIPIENT': fetch_parameter(SSM_CLIENT, f'/secure-contact/{STAGE}/prodmon-recipient'),
         'SECUREDROP_URL': fetch_parameter(SSM_CLIENT, "securedrop-url"),
+        'SECUREDROP_URL_HUMAN': fetch_parameter(SSM_CLIENT, "securedrop-url-human"),
         'TABLE_NAME': f'MonitorHistory-{STAGE}'
     }
 
     if CONFIG['BUCKET_NAME'] is not None:
-        build_pages(CONFIG['SECUREDROP_URL'], STAGE)
+        build_pages(CONFIG['SECUREDROP_URL'], CONFIG['SECUREDROP_URL_HUMAN'], STAGE)
         run(SESSION, CONFIG)


### PR DESCRIPTION
## What does this change?
Add a new parameter to be fetched from parameter store responsible to store the value of the human readable tor URL.
Also fix the main monitor python script to include the human url parameter
## How to test
Test in CODE