### PR TITLE
Add CI for secure-drop-monitor and change url for tails download to new tails.net

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+# Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: CI
+
+on:
+  pull_request:
+
+  # Manual invocation.
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+jobs:
+  CI:
+    name: Build project files and upload
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials (deployTools)
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Upload secure-drop-monitor to riff-raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          app: monitor
+          configPath: secure-drop-monitor-riff-raff.yaml
+          projectName: InfoSec::secure-drop
+          contentDirectories: |
+            secure-drop-monitor-cloudformation:
+              - cloudformation/secure-contact.template.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
           configPath: secure-drop-monitor-riff-raff.yaml
           projectName: InfoSec::secure-drop
           contentDirectories: |
-            secure-drop-monitor-cloudformation:
+            secure-contact-monitor-cloudformation:
               - cloudformation/secure-contact.template.yaml

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -62,6 +62,13 @@ Parameters:
     Description: Email notified if the healtcheck failed
     Type: String
 
+  App:
+    Type: String
+    Default: secure-contact-monitor
+
+  Stack:
+    Type: String
+
 
 Resources:
 
@@ -384,10 +391,13 @@ Resources:
       Tags:
         - Key: Stack
           Value: !Ref Stack
+          PropagateAtLaunch: true
         - Key: App
           Value: !Ref App
+          PropagateAtLaunch: true
         - Key: Stage
           Value: !Ref Stage
+          PropagateAtLaunch: true
         - Key: Name
           Value: !Sub ${AWS::StackName}
           PropagateAtLaunch: true

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -313,7 +313,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: t3.micro
+      InstanceType: t4g.nano
       IamInstanceProfile:
         Ref: SecureContactInstanceProfile
       AssociatePublicIpAddress: true

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -316,7 +316,7 @@ Resources:
       InstanceType: t4g.nano
       IamInstanceProfile:
         Ref: SecureContactInstanceProfile
-      AssociatePublicIpAddress: false
+      AssociatePublicIpAddress: true
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -382,10 +382,9 @@ Resources:
       LaunchConfigurationName:
         Ref: LaunchConfig
       MinSize: 0
-      MaxSize: 1
-      DesiredCapacity: 1
+      MaxSize: 2
       HealthCheckType: ELB
-      HealthCheckGracePeriod: 300
+      HealthCheckGracePeriod: 600
       LoadBalancerNames:
       - Ref: LoadBalancer
       Tags:

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -316,7 +316,7 @@ Resources:
       InstanceType: t4g.nano
       IamInstanceProfile:
         Ref: SecureContactInstanceProfile
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: false
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -25,13 +25,6 @@ Metadata:
       Parameters:
       - AlertEmail
 
-Mappings:
-  Constants:
-    Stack:
-      Value: secure-contact
-    App:
-      Value: monitor
-
 Parameters:
   SSHAccessCidr:
     Description: A CIDR from which access to the instance is allowed
@@ -104,11 +97,9 @@ Resources:
         Enabled: true
       Tags:
         - Key: Stack
-          Value:
-            Fn::FindInMap: [ Constants, Stack, Value ]
+          Value: !Ref Stack
         - Key: App
-          Value:
-            Fn::FindInMap: [ Constants, App, Value ]
+          Value: !Ref App
         - Key: Stage
           Value: !Ref Stage
         - Key: Name
@@ -134,16 +125,14 @@ Resources:
           ToPort: 80
           CidrIp: !Ref SSHAccessCidr
       Tags:
-      - Key: Stack
-        Value:
-          Fn::FindInMap: [ Constants, Stack, Value ]
-      - Key: App
-        Value:
-          Fn::FindInMap: [ Constants, App, Value ]
-      - Key: Stage
-        Value: !Ref Stage
-      - Key: Name
-        Value: !Sub ${AWS::StackName} LoadBalancer
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Name
+          Value: !Sub ${AWS::StackName} LoadBalancer
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
@@ -164,11 +153,9 @@ Resources:
       - Ref: LoadBalancerSecurityGroup
       Tags:
         - Key: Stack
-          Value:
-            Fn::FindInMap: [ Constants, Stack, Value ]
+          Value: !Ref Stack
         - Key: App
-          Value:
-            Fn::FindInMap: [ Constants, App, Value ]
+          Value: !Ref App
         - Key: Stage
           Value: !Ref Stage
         - Key: Name
@@ -303,16 +290,14 @@ Resources:
         ToPort: 443
         CidrIp: 0.0.0.0/0
       Tags:
-      - Key: Stack
-        Value:
-          Fn::FindInMap: [ Constants, Stack, Value ]
-      - Key: App
-        Value:
-          Fn::FindInMap: [ Constants, App, Value ]
-      - Key: Stage
-        Value: !Ref Stage
-      - Key: Name
-        Value: !Sub ${AWS::StackName} Instance
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Name
+          Value: !Sub ${AWS::StackName} Instance
 
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -397,20 +382,15 @@ Resources:
       LoadBalancerNames:
       - Ref: LoadBalancer
       Tags:
-      - Key: App
-        Value:
-          Fn::FindInMap: [ Constants, App, Value ]
-        PropagateAtLaunch: true
-      - Key: Stack
-        Value:
-          Fn::FindInMap: [ Constants, Stack, Value ]
-        PropagateAtLaunch: true
-      - Key: Stage
-        Value: !Ref Stage
-        PropagateAtLaunch: true
-      - Key: Name
-        Value: !Sub ${AWS::StackName}
-        PropagateAtLaunch: true
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: App
+          Value: !Ref App
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Name
+          Value: !Sub ${AWS::StackName}
+          PropagateAtLaunch: true
 
   NotificationTopic:
     Type: AWS::SNS::Topic

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -19,8 +19,7 @@ deployments:
     type: autoscaling
     parameters:
       healthcheckGrace: 300
-      secondsToWait: 1200
-      warmupGrace: 1200
+      warmupGrace: 300
     dependencies:
       - secure-contact-monitor-cloudformation
     actions:

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -17,9 +17,10 @@ deployments:
   secure-contact-monitor-autoscaling:
     app: secure-contact-monitor
     type: autoscaling
-    healthcheckGrace: 300
-    secondsToWait: 1200
-    warmupGrace: 1200
+    parameters:
+      healthcheckGrace: 300
+      secondsToWait: 1200
+      warmupGrace: 1200
     dependencies:
       - secure-contact-monitor-cloudformation
     actions:

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
           AmigoStage: PROD
           Recipe: infosec-secure-contact
       amiEncrypted: true
-      templatePath: secure-drop-monitor-cloudformation/secure-contact.template.yaml
+      templatePath: secure-contact.template.yaml
   secure-contact-monitor-autoscaling:
     app: secure-contact-monitor
     type: autoscaling

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -13,6 +13,7 @@ deployments:
           AmigoStage: PROD
           Recipe: infosec-secure-contact
       amiEncrypted: true
+      templatePath: secure-contact.template.yaml
   secure-contact-monitor-autoscaling:
     app: secure-contact-monitor
     type: autoscaling

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -17,6 +17,9 @@ deployments:
   secure-contact-monitor-autoscaling:
     app: secure-contact-monitor
     type: autoscaling
+    healthcheckGrace: 300
+    secondsToWait: 1200
+    warmupGrace: 1200
     dependencies:
       - secure-contact-monitor-cloudformation
     actions:

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
           AmigoStage: PROD
           Recipe: infosec-secure-contact
       amiEncrypted: true
-      templatePath: secure-contact.template.yaml
+      templatePath: secure-drop-monitor-cloudformation/secure-contact.template.yaml
   secure-contact-monitor-autoscaling:
     app: secure-contact-monitor
     type: autoscaling

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -1,0 +1,22 @@
+stacks: [infosec]
+regions: [eu-west-1]
+
+deployments:
+
+  secure-contact-monitor-cloudformation:
+    app: secure-contact-monitor
+    type: cloud-formation
+    parameters:
+      amiParametersToTags:
+        AMI:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: infosec-secure-contact
+      amiEncrypted: true
+  secure-contact-monitor-autoscaling:
+    app: secure-contact-monitor
+    type: autoscaling
+    dependencies:
+      - secure-contact-monitor-cloudformation
+    actions:
+      - deploy

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -168,7 +168,10 @@ def run(session: Session, config: Dict[str, str]):
         if passes_healthcheck:
             logger.info(f'Healthcheck: passed on attempt {attempts}')
             upload_website_index(session, config, passes_healthcheck)
-            send_message(config, passes_healthcheck)
+            if get_uptime() < 3600:
+                send_message(config, passes_healthcheck)
+            elif hour_is_0900():
+                send_message(config, passes_healthcheck)
             break
         logger.info(f'Healthcheck: unable to reach site on attempt {attempts}')
         time.sleep(60)

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -79,11 +79,23 @@ def healthcheck(response: Optional[requests.Response]) -> bool:
             return True
     return False
 
+def get_uptime():
+    with open('/proc/uptime', 'r') as f:
+        uptime_seconds = float(f.readline().split()[0])
+
+    return uptime_seconds
+
 
 def get_expiry(current_time: int) -> int:
     # There are 604800 seconds in a week
     return current_time + 604800
 
+
+def hour_is_0900():
+    if int(time.strftime("%H"))==9:
+        return True
+    else:
+        return False
 
 def create_item(current_time: int, outcome: bool) -> Dict[str, str]:
     expiration = get_expiry(current_time)

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -181,6 +181,7 @@ if __name__ == '__main__':
         'PRODMON_WEBHOOK': fetch_parameter(SSM_CLIENT, f'/secure-contact/{STAGE}/prodmon-webhook'),
         'PRODMON_SENDER': fetch_parameter(SSM_CLIENT, f'/secure-contact/{STAGE}/prodmon-sender'),
         'PRODMON_RECIPIENT': fetch_parameter(SSM_CLIENT, f'/secure-contact/{STAGE}/prodmon-recipient'),
+        'PRODMON_REDEPLOY_URL': fetch_parameter(SSM_CLIENT, f'/secure-contact/{STAGE}/prodmon-redeploy-url'),
         'SECUREDROP_URL': fetch_parameter(SSM_CLIENT, "securedrop-url"),
         'SECUREDROP_URL_HUMAN': fetch_parameter(SSM_CLIENT, "securedrop-url-human"),
         'TABLE_NAME': f'MonitorHistory-{STAGE}'

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -77,8 +77,7 @@ def send_email(session: Session, config: Dict[str, str], message: Dict):
     else:
         logger.info(f'Email sent! Message ID: {response["MessageId"]}')
 
-
-def generate_message(card_title: str, card_subtitle: str, message_text: str) -> Dict:
+def generate_message(card_title: str, card_subtitle: str, message_text: str, redeploy_url: str) -> Dict:
     return {
         "text": message_text,
         "cards": [
@@ -86,7 +85,27 @@ def generate_message(card_title: str, card_subtitle: str, message_text: str) -> 
                 "header": {
                     "title": card_title,
                     "subtitle": card_subtitle
-                }
+                },
+                "sections": [
+                    {
+                        "widgets": [
+                            {
+                                "buttons": [
+                                    {
+                                        "textButton": {
+                                            "text": "Redeploy via Riff-Raff",
+                                            "onClick": {
+                                                "openLink": {
+                                                    "url": redeploy_url
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }
@@ -97,7 +116,7 @@ def send_message(config: Dict[str, str], passed: bool):
     headers = {'Content-Type': 'application/json; charset=UTF-8'}
     status = 'Status: 💚💚💚' if passed else 'Status: 💔💔💔'
     message_text = '' if passed else '*Attention <users/all> Healthcheck has failed*'
-    message_data = json.dumps(generate_message('SecureDrop Monitor', status, message_text))
+    message_data = json.dumps(generate_message('SecureDrop Monitor', status, message_text, config['PRODMON_REDEPLOY_URL']))
 
     try:
         response = requests.post(url=config['PRODMON_WEBHOOK'], headers=headers, data=message_data)

--- a/templates/public/securedrop.html
+++ b/templates/public/securedrop.html
@@ -57,7 +57,7 @@
         <ol class="circles-list">
           <li class="gu-text">
             Download and install software to access the Tor network: <a href="https://torproject.org/">https://www.torproject.org</a>.
-            For security reasons, we advise you, especially if you are uploading documents, not to use your home or work network, but instead to use a public Wi-Fi network in an  area where your screen is not visible to security cameras. Alternately, you can start up your computer from a USB key loaded with the Tails secure operating system, which is available at <a href="https://tails.boum.org/">https://tails.boum.org</a> and includes the Tor web browser.
+            For security reasons, we advise you, especially if you are uploading documents, not to use your home or work network, but instead to use a public Wi-Fi network in an  area where your screen is not visible to security cameras. Alternately, you can start up your computer from a USB key loaded with the Tails secure operating system, which is available at <a href="https://tails.net/">https://tails.net</a> and includes the Tor web browser.
           </li>
           <li class="gu-text">
             Once you launch the Tor browser, copy and paste the URL <span class="onion-url">{{ securedrop_url }}</span> or <span class="onion-url">{{ securedrop_url_human }}</span> into the Tor address bar. When the page loads, you will find further instructions on how to submit files and messages to the Guardian.


### PR DESCRIPTION
## What does this change?

This changes the URL on the secure-drop landing page from tails.boum.org to the new tails.net URL. 

CI/riff-raff config has also been added so cycling a broken monitor will be easier. I've also added a link to the Google Chat message (on failure) to redeploy via riff-raff.