### PR TITLE
Remove branch name that was used for testing

### DIFF
--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -340,7 +340,7 @@ Resources:
 
           # install application
           mkdir /secure-contact
-          git clone -b lh-2023-09-08-reliability-improvements https://github.com/guardian/secure-contact /secure-contact
+          git clone https://github.com/guardian/secure-contact /secure-contact
 
           # install python packages and run monitor once
           cd /secure-contact


### PR DESCRIPTION
## What does this change?

The branch that was used for testing was mistakenly pushed to main. This change removes the branch, which no longer exists, and causes the monitor autoscaling group to enter a spin cycle. 