### PR TITLE
Upgrade actions-riff-raff to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials (deployTools)
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Upload secure-drop-monitor to riff-raff
-        uses: guardian/actions-riff-raff@v2
+        uses: guardian/actions-riff-raff@v4
         with:
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           app: monitor
           configPath: secure-drop-monitor-riff-raff.yaml
           projectName: InfoSec::secure-drop


### PR DESCRIPTION
## What does this change?
- Follow directions in actions-riff-raff to upgrade from version 2 to 4.
  - [v2 to v3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0)
  - [v3 to v4](https://github.com/guardian/actions-riff-raff?tab=readme-ov-file#migrating-from-v3-to-v4)



## Why?
v4 avoids the need for configure-aws-credentials which stores aws credentials in an environment variables, allowing other, possibly malicious, actions to access them.