### PR TITLE
Security improvement chore - Use AWS metadata service v2, riff-raff actions v4 and remove elastic IP from monitor instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,16 @@ jobs:
       # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials (deployTools)
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Upload secure-drop-monitor to riff-raff
-        uses: guardian/actions-riff-raff@v2
+        uses: guardian/actions-riff-raff@v4
         with:
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           app: monitor
           configPath: secure-drop-monitor-riff-raff.yaml
           projectName: InfoSec::secure-drop

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -323,6 +323,9 @@ Resources:
       IamInstanceProfile:
         Ref: SecureContactInstanceProfile
       AssociatePublicIpAddress: false
+      MetadataOptions:
+        HttpTokens: required
+        InstanceMetadataTags: enabled
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -69,50 +69,15 @@ Parameters:
   Stack:
     Type: String
 
-
 Resources:
 
   SecureDropBucketParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Description: S3 bucket that holds the site content
-      Name: !Sub /secure-contact/${Stage}/securedrop-public-bucket
+      Name: !Sub /${App}/${Stage}/securedrop-public-bucket
       Type: String
       Value: !Ref PublicBucket
-
-  # if you update this then you should also update the dev_database script
-  MonitorHistoryTable:
-    Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    Properties:
-      TableName: !Sub MonitorHistory-${Stage}
-      AttributeDefinitions:
-        - AttributeName: CheckTime
-          AttributeType: N
-        - AttributeName: Outcome
-          AttributeType: S
-      KeySchema:
-        - AttributeName: CheckTime
-          KeyType: HASH
-        - AttributeName: Outcome
-          KeyType: RANGE
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
-      TimeToLiveSpecification:
-        AttributeName: ExpirationTime
-        Enabled: true
-      Tags:
-        - Key: Stack
-          Value: !Ref Stack
-        - Key: App
-          Value: !Ref App
-        - Key: Stage
-          Value: !Ref Stage
-        - Key: Name
-          Value: !Sub ${AWS::StackName}
-        - Key: devx-backup-enabled
-          Value: false
 
 # ----------------------- #
 #  LOADBALANCER           #
@@ -128,11 +93,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: !Ref SSHAccessCidr
+          CidrIp: !Ref AccessCidr
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: !Ref SSHAccessCidr
+          CidrIp: !Ref AccessCidr
       Tags:
         - Key: Stack
           Value: !Ref Stack
@@ -220,16 +185,6 @@ Resources:
               Action:
                 - S3:PutBucketWebsite
                 - S3:PutObject
-            # allow instance to read from and append to the database table
-            - Effect: Allow
-              Action:
-                - dynamodb:GetItem
-                - dynamodb:BatchGetItem
-                - dynamodb:Query
-                - dynamodb:PutItem
-                - dynamodb:DescribeTable
-              Resource:
-                - Fn::GetAtt: [ MonitorHistoryTable, Arn ]
 
   # Minimal policy to run commands via ssm and use ssm-scala
   SSMRunCommandPolicy:

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -299,7 +299,7 @@ Resources:
 
           # install application
           mkdir /secure-contact
-          git clone -b lh-2024-04-09-metadata-v2 https://github.com/guardian/secure-contact /secure-contact
+          git clone https://github.com/guardian/secure-contact /secure-contact
 
           # install python packages and run monitor once
           cd /secure-contact

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -7,7 +7,7 @@ Metadata:
     - Label:
         default: Security
       Parameters:
-      - SSHAccessCidr
+      - AccessCidr
     - Label:
         default: Networking
       Parameters:
@@ -20,27 +20,25 @@ Metadata:
       - AMI
       - Stage
       - PublicBucket
-    - Label:
-        default: Other
-      Parameters:
-      - AlertEmail
 
 Parameters:
-  SSHAccessCidr:
+  AccessCidr:
     Description: A CIDR from which access to the instance is allowed
-    AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
-    ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
-    Type: String
+    Default: /account/services/kp-public-cidr
+    Type: AWS::SSM::Parameter::Value<String>
 
   VpcId:
     Description: ID of the VPC onto which to launch the stack
-    Type: AWS::EC2::VPC::Id
+    Default: /account/vpc/primary/id
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>
   LoadBalancerSubnets:
     Description: Subnets to use in VPC for public ELB
-    Type: List<AWS::EC2::Subnet::Id>
+    Default: /account/vpc/primary/subnets/public
+    Type: AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>
   InstanceSubnets:
     Description: Subnets to use in VPC for instances
-    Type: List<AWS::EC2::Subnet::Id>
+    Default: /account/vpc/primary/subnets/private
+    Type: AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>
 
   AMI:
     Description: Base AMI for SecureContact instances
@@ -53,14 +51,16 @@ Parameters:
     - CODE
     - DEV
     Default: CODE
-
+#
   PublicBucket:
     Description: Name of the public S3 bucket that hosts the website
-    Type: String
+    Default: !Sub /secure-drop/${Stage}/securedrop-public-bucket
+    Type: AWS::SSM::Parameter::Value<String>
 
   AlertEmail:
     Description: Email notified if the healtcheck failed
-    Type: String
+    Default: !Sub /secure-drop/${Stage}/prodmod-recipient
+    Type: AWS::SSM::Parameter::Value<List<String>>
 
   App:
     Type: String

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -51,16 +51,14 @@ Parameters:
     - CODE
     - DEV
     Default: CODE
-#
+
   PublicBucket:
     Description: Name of the public S3 bucket that hosts the website
-    Default: !Sub /secure-drop/${Stage}/securedrop-public-bucket
-    Type: AWS::SSM::Parameter::Value<String>
+    Type: String
 
   AlertEmail:
     Description: Email notified if the healtcheck failed
-    Default: !Sub /secure-drop/${Stage}/prodmod-recipient
-    Type: AWS::SSM::Parameter::Value<List<String>>
+    Type: String
 
   App:
     Type: String
@@ -280,7 +278,6 @@ Resources:
       AssociatePublicIpAddress: false
       MetadataOptions:
         HttpTokens: required
-        InstanceMetadataTags: enabled
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev
@@ -302,7 +299,7 @@ Resources:
 
           # install application
           mkdir /secure-contact
-          git clone -b lh-2024-01-16-flask-werkzeug-2.2.2-deps https://github.com/guardian/secure-contact  /secure-contact
+          git clone -b lh-2024-04-09-metadata-v2 https://github.com/guardian/secure-contact /secure-contact
 
           # install python packages and run monitor once
           cd /secure-contact

--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -322,11 +322,13 @@ Resources:
       InstanceType: t4g.micro
       IamInstanceProfile:
         Ref: SecureContactInstanceProfile
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: false
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev
-
+          TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" \
+          -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` \
+          && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/
           echo ${Stage} > /etc/stage
 
           apt-get update && apt-get install -y apt-transport-https

--- a/secure-drop-monitor-riff-raff.yaml
+++ b/secure-drop-monitor-riff-raff.yaml
@@ -4,7 +4,7 @@ regions: [eu-west-1]
 deployments:
 
   secure-drop-monitor-cloudformation:
-    app: secure-drop-monitor
+    app: secure-contact-monitor
     type: cloud-formation
     parameters:
       amiParametersToTags:
@@ -15,7 +15,7 @@ deployments:
       amiEncrypted: true
       templatePath: secure-contact.template.yaml
   secure-drop-monitor-autoscaling:
-    app: secure-drop-monitor
+    app: secure-contact-monitor
     type: autoscaling
     parameters:
       healthcheckGrace: 420


### PR DESCRIPTION
## What does this change?

This change has a number of small security improvements - we don't need an elastic IP on this instance for any reason, and AWS FSBP recommends instances do not have their own elastic IPs. 

We're also migrating from riff-raff actions v3 to v4, which uses a more secure method for getting Github and RiffRaff tokens. 

FSBP also recommends you use metadata service v2, which requires the use of a token to retrieve your metadata/userdata. 

## How to test

Deploy on CODE

## How can we measure success?

FSBP security recommendations are resolved for this App/Stack. 