### PR TITLE
Remove Wazuh references and rules

### DIFF
--- a/cloudformation/secure-contact.template.yaml
+++ b/cloudformation/secure-contact.template.yaml
@@ -251,10 +251,6 @@ Resources:
         FromPort: 443
         ToPort: 443
         CidrIp: 0.0.0.0/0
-      - IpProtocol: tcp
-        FromPort: 1514
-        ToPort: 1515
-        CidrIp: '{{resolve:ssm:/account/services/wazuh-manager-ipv4}}/32'
       Tags:
         - Key: Stack
           Value: !Ref Stack


### PR DESCRIPTION
## What does this change?

Wazuh is [being decommissioned](https://github.com/guardian/amigo/pull/1601) - various references to Wazuh in documentation need to be cleared up clarity, and other things like security group rules in various places.