### PR TITLE
Update 'How to contact the Guardian securely' link on the securedrop page

### DIFF
--- a/templates/public/securedrop.html
+++ b/templates/public/securedrop.html
@@ -26,7 +26,7 @@
               Use of the Tor network helps hide your identity online, but it does not guarantee the safety of the computer that you use to contact us. We recommend that you avoid accessing SecureDrop from small networks where use of a Tor browser may be monitored or restricted. If there is any risk of your browser activity being recorded, it's advisable not to jump straight from this information page to the actual Guardian SecureDrop site. You could instead make a note of the SecureDrop ‘onion’ URL (see below) and then wait to connect to that site at another time or on a different computer.
           </p>
           <p class="gu-text">
-            If SecureDrop is not the right tool for you, please consider some of the other options in our interactive guide: <a href="https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely">How to contact the Guardian securely</a>.
+            If SecureDrop is not the right tool for you, please consider some of the other options in our interactive guide: <a href="https://www.theguardian.com/tips">How to contact the Guardian securely</a>.
           </p>
       </div>
   </section>


### PR DESCRIPTION
## What does this change?

Update link for 'How to contact the Guardian securely'

From:

https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely

to 

https://www.theguardian.com/tips 
